### PR TITLE
Github Navbar Link

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -7,4 +7,4 @@ status-website:
   name: Upptime
   introTitle: "**Upptime** is the open-source uptime monitor and status page, powered entirely by GitHub."
   introMessage: This is a sample status page which uses **real-time** data from our [Github repository](https://github.com/koj-co/upptime). No server required — just GitHub Actions, Issues, and Pages. [**Get your own for free**](https://github.com/koj-co/upptime)
-  gitHubNavBar: true
+  navbarGitHub: true

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -7,3 +7,4 @@ status-website:
   name: Upptime
   introTitle: "**Upptime** is the open-source uptime monitor and status page, powered entirely by GitHub."
   introMessage: This is a sample status page which uses **real-time** data from our [Github repository](https://github.com/koj-co/upptime). No server required — just GitHub Actions, Issues, and Pages. [**Get your own for free**](https://github.com/koj-co/upptime)
+  gitHubNavBar: true

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -1,10 +1,40 @@
 owner: koj-co
 repo: upptime
+user-agent: KojBot
+
+# Add your sites here
+sites:
+  - name: Google
+    url: https://www.google.com
+  - name: Wikipedia
+    url: https://en.wikipedia.org
+  - name: Internet Archive
+    url: https://archive.org
+  - name: Hacker News
+    url: https://news.ycombinator.com
+  - name: Broken Site
+    url: https://thissitedoesnotexist.com
+  - name: Secret Site
+    url: $SECRET_SITE
+
+# Add downtime notifications
+# https://upptime.js.org/docs/notifications
+notifications:
+  - type: slack
+    channel: C016QTU9S9Y
+assignees:
+  - AnandChowdhary
+
+# Configure your status website
+# http://localhost:3000/docs/configuration#status-website
 status-website:
-  cname: upptime.js.org
-  baseUrl: /status-website
-  logoUrl: https://raw.githubusercontent.com/koj-co/upptime/79d9d1c22ecf706acc51f17798d7c7dbc710ab40/assets/icon.svg
+  cname: demo.upptime.js.org
+  logoUrl: https://raw.githubusercontent.com/upptime/upptime.js.org/master/static/img/icon.svg
   name: Upptime
   introTitle: "**Upptime** is the open-source uptime monitor and status page, powered entirely by GitHub."
   introMessage: This is a sample status page which uses **real-time** data from our [Github repository](https://github.com/koj-co/upptime). No server required — just GitHub Actions, Issues, and Pages. [**Get your own for free**](https://github.com/koj-co/upptime)
-  navbarGitHub: true
+  navbar:
+    - title: Status
+      href: /
+    - title: GitHub
+      href: https://github.com/$OWNER/$REPO

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ We use the [upptime/upptime](https://github.com/upptime/upptime) repository for 
 
 When you use Upptime, we automatically generate a static status website and push it to the `gh-pages` branch. You don't have to manually manage any code from this repository.
 
+When building locally, you can start a server:
+
+```bash
+npm run dev
+```
+
+Currently, the `.upptimerc.yml` configuration file is required one directly above the project root.
+
 ## 📄 License
 
 [MIT](./LICENSE) © [Koj](https://koj.co)

--- a/i18n.yml
+++ b/i18n.yml
@@ -25,6 +25,5 @@ up: Up
 down: Down
 ms: ms
 loading: Loading
-navStatus: Status
 navGitHub: GitHub
 footer: This page is [open source]($REPO), powered by [Upptime](https://upptime.js.org)

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -69,10 +69,12 @@
           {config.i18n.navStatus}
         </a>
       </li>
-      {#if config['status-website'] && config['status-website'].gitHubNavBar}
-      <li>
-        <a href={`https://github.com/${config.owner}/${config.repo}`}> {config.i18n.navGitHub} </a>
-      </li>
+      {#if config['status-website'] && config['status-website'].navbarGitHub}
+        <li>
+          <a href={`https://github.com/${config.owner}/${config.repo}`}>
+            {config.i18n.navGitHub}
+          </a>
+        </li>
       {/if}
     </ul>
   </div>

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -64,12 +64,18 @@
       </div>
     {/if}
     <ul>
-      <li>
-        <a aria-current={segment === undefined ? 'page' : undefined} href="/">
-          {config.i18n.navStatus}
-        </a>
-      </li>
-      {#if config['status-website'] && config['status-website'].navbarGitHub}
+      {#if config['status-website'] && config['status-website'].navbar}
+        {#each config['status-website'].navbar as item}
+          <li>
+            <a
+              aria-current={segment === (item.href === '/' ? undefined : item.href) ? 'page' : undefined}
+              href={item.href}>
+              {item.title}
+            </a>
+          </li>
+        {/each}
+      {/if}
+      {#if config['status-website'] && config['status-website'].navbarGitHub && !config['status-website'].navbar}
         <li>
           <a href={`https://github.com/${config.owner}/${config.repo}`}>
             {config.i18n.navGitHub}

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -69,9 +69,11 @@
           {config.i18n.navStatus}
         </a>
       </li>
+      {#if config['status-website'] && config['status-website'].gitHubNavBar}
       <li>
         <a href={`https://github.com/${config.owner}/${config.repo}`}> {config.i18n.navGitHub} </a>
       </li>
+      {/if}
     </ul>
   </div>
 </nav>

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -69,7 +69,7 @@
           <li>
             <a
               aria-current={segment === (item.href === '/' ? undefined : item.href) ? 'page' : undefined}
-              href={item.href}>
+              href={item.href.replace('$OWNER', config.owner).replace('$REPO', config.repo)}>
               {item.title}
             </a>
           </li>


### PR DESCRIPTION
Added an option to disable the **navbar** github link, to prevent non-tech-savvy people from accidentally clicking the link, and not know how to get back. This does **not** effect the footer github link.