### PR TITLE
Add the possibility to configure the base URL of the GitHub API

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -31,6 +31,7 @@ status-website:
   cname: demo.upptime.js.org
   logoUrl: https://raw.githubusercontent.com/upptime/upptime.js.org/master/static/img/icon.svg
   name: Upptime
+  apiBaseUrl: https://api.github.com
   introTitle: "**Upptime** is the open-source uptime monitor and status page, powered entirely by GitHub."
   introMessage: This is a sample status page which uses **real-time** data from our [Github repository](https://github.com/koj-co/upptime). No server required — just GitHub Actions, Issues, and Pages. [**Get your own for free**](https://github.com/koj-co/upptime)
   navbar:

--- a/src/components/ActiveIncidents.svelte
+++ b/src/components/ActiveIncidents.svelte
@@ -1,13 +1,11 @@
 <script>
   import Loading from "../components/Loading.svelte";
-  import { Octokit } from "@octokit/rest";
   import { onMount } from "svelte";
   import config from "../data/config.json";
+  import { createOctokit } from "../utils/createOctokit";
 
   let loading = true;
-  const octokit = new Octokit({
-    userAgent: config["user-agent"],
-  });
+  const octokit = createOctokit();
   const owner = config.owner;
   const repo = config.repo;
   let incidents = [];

--- a/src/components/Graph.svelte
+++ b/src/components/Graph.svelte
@@ -1,15 +1,13 @@
 <script>
   import Loading from "../components/Loading.svelte";
-  import { Octokit } from "@octokit/rest";
   import { onMount } from "svelte";
   import config from "../data/config.json";
   import Line from "svelte-chartjs/src/Line.svelte";
+  import { createOctokit } from "../utils/createOctokit";
 
   export let slug;
   let loading = true;
-  const octokit = new Octokit({
-    userAgent: config["user-agent"],
-  });
+  const octokit = createOctokit();
   const owner = config.owner;
   const repo = config.repo;
   let commits = [];
@@ -34,9 +32,7 @@
     });
     data = commits
       .filter((commit) => commit.commit.message.includes("ms) [skip ci]"))
-      .map((commit) =>
-        parseInt(commit.commit.message.split(" in ")[1].split("ms")[0])
-      );
+      .map((commit) => parseInt(commit.commit.message.split(" in ")[1].split("ms")[0]));
     labels = commits
       .filter((commit) => commit.commit.message.includes("ms) [skip ci]"))
       .map((commit) => new Date(commit.commit.committer.date).toLocaleString());
@@ -45,7 +41,6 @@
 </script>
 
 <style>
-
 </style>
 
 <section>

--- a/src/components/History.svelte
+++ b/src/components/History.svelte
@@ -1,14 +1,12 @@
 <script>
   import Loading from "../components/Loading.svelte";
-  import { Octokit } from "@octokit/rest";
   import { onMount } from "svelte";
   import config from "../data/config.json";
+  import { createOctokit } from "../utils/createOctokit";
 
   export let slug;
   let loading = true;
-  const octokit = new Octokit({
-    userAgent: config["user-agent"],
-  });
+  const octokit = createOctokit();
   const owner = config.owner;
   const repo = config.repo;
   let incidents = [];

--- a/src/components/Incident.svelte
+++ b/src/components/Incident.svelte
@@ -1,9 +1,9 @@
 <script>
   import Loading from "../components/Loading.svelte";
-  import { Octokit } from "@octokit/rest";
   import { onMount } from "svelte";
   import snarkdown from "snarkdown";
   import config from "../data/config.json";
+  import { createOctokit } from "../utils/createOctokit";
 
   export let number;
 
@@ -11,9 +11,7 @@
   let loading = true;
   let loadingIncident = true;
 
-  const octokit = new Octokit({
-    userAgent: config["user-agent"],
-  });
+  const octokit = createOctokit();
   const owner = config.owner;
   const repo = config.repo;
   let comments = [];

--- a/src/components/Incidents.svelte
+++ b/src/components/Incidents.svelte
@@ -1,13 +1,11 @@
 <script>
   import Loading from "../components/Loading.svelte";
-  import { Octokit } from "@octokit/rest";
   import { onMount } from "svelte";
   import config from "../data/config.json";
+  import { createOctokit } from "../utils/createOctokit";
 
   let loading = true;
-  const octokit = new Octokit({
-    userAgent: config["user-agent"],
-  });
+  const octokit = createOctokit();
   const owner = config.owner;
   const repo = config.repo;
   let incidents = [];

--- a/src/components/LiveStatus.svelte
+++ b/src/components/LiveStatus.svelte
@@ -1,16 +1,19 @@
 <script>
   import Loading from "../components/Loading.svelte";
-  import { Octokit } from "@octokit/rest";
   import { onMount } from "svelte";
   import config from "../data/config.json";
+  import { createOctokit } from "../utils/createOctokit";
 
   let loading = true;
-  const octokit = new Octokit({
-    userAgent: config["user-agent"],
-  });
+  const octokit = createOctokit();
   const owner = config.owner;
   const repo = config.repo;
+  const { apiBaseUrl } = config["status-website"];
   let sites = [];
+
+  const isGitHubApi = apiBaseUrl.includes("api.github.com");
+  const userContentBaseUrl = isGitHubApi ? `https://raw.githubusercontent.com` : apiBaseUrl;
+  const graphsBaseUrl = `${userContentBaseUrl}/${owner}/${repo}/master/graphs`;
 
   onMount(async () => {
     sites = JSON.parse(
@@ -44,7 +47,7 @@
     {#each sites as site}
       <article
         class={`${site.status} link`}
-        style={`background-image: url("https://raw.githubusercontent.com/${owner}/${repo}/master/graphs/${site.slug}.png`}>
+        style={`background-image: url("${graphsBaseUrl}/${site.slug}.png`}>
         <h4><a href={`history/${site.slug}`}>{site.name}</a></h4>
         <div>
           {@html config.i18n.overallUptime.replace(/\$UPTIME/g, site.uptime)}

--- a/src/components/Summary.svelte
+++ b/src/components/Summary.svelte
@@ -1,14 +1,12 @@
 <script>
   import Loading from "../components/Loading.svelte";
-  import { Octokit } from "@octokit/rest";
   import { onMount } from "svelte";
   import config from "../data/config.json";
+  import { createOctokit } from "../utils/createOctokit";
 
   export let slug;
   let loading = true;
-  const octokit = new Octokit({
-    userAgent: config["user-agent"],
-  });
+  const octokit = createOctokit();
   const owner = config.owner;
   const repo = config.repo;
   let summary = null;
@@ -30,7 +28,6 @@
 </script>
 
 <style>
-
 </style>
 
 <section>

--- a/src/utils/createOctokit.js
+++ b/src/utils/createOctokit.js
@@ -1,0 +1,11 @@
+import { Octokit } from "@octokit/rest";
+import config from "../data/config.json";
+
+const { apiBaseUrl: baseUrl } = config["status-website"]
+const userAgent = config.userAgent;
+
+export const createOctokit = () =>
+  new Octokit({
+    baseUrl,
+    userAgent,
+  });


### PR DESCRIPTION
This PR introduces a way of configuring the base URL of the API with which the frontend should communicate. The implementation is the result of the brainstorming in https://github.com/upptime/upptime/issues/54 where @AnandChowdhary and I discussed ways on how to use `upptime` with private repositories. One option would be to create a lightweight proxy which provides the same API surface as the original GitHub API, but makes authorized calls against the actual GitHub production API. For signalling the frontend against which API it should communicate, the introduction of a new configuration was necessary.

I tested it locally against a rudimentary proxy I just hacked together and it worked like a charm 🙂 