### PR TITLE
It would be great to be able to go directly to the site being measured from the summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5702,7 +5702,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "handlebars": {
       "version": "4.7.6",
@@ -6310,6 +6311,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -9700,6 +9702,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -9714,6 +9717,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -9723,6 +9727,7 @@
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -14799,7 +14804,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "shimport": {
       "version": "2.0.4",
@@ -15938,7 +15944,8 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "v8-to-istanbul": {
       "version": "7.0.0",

--- a/src/components/Summary.svelte
+++ b/src/components/Summary.svelte
@@ -27,6 +27,9 @@
 </script>
 
 <style>
+  a {
+    text-decoration: none;
+  }
 </style>
 
 <section>
@@ -34,7 +37,7 @@
     <Loading />
   {:else if summary}
     <h1>
-      {summary.name}
+      <a class="" href={summary.url}>{summary.name}</a>
       <span class={`tag ${summary.status}`}>
         {summary.status === 'up' ? config.i18n.up : config.i18n.down}
       </span>

--- a/src/components/Summary.svelte
+++ b/src/components/Summary.svelte
@@ -27,7 +27,7 @@
 </script>
 
 <style>
-  a {
+  .no-underline {
     text-decoration: none;
   }
 </style>
@@ -37,7 +37,7 @@
     <Loading />
   {:else if summary}
     <h1>
-      <a class="" href={summary.url}>{summary.name}</a>
+      <a class="no-underline" href={summary.url}>{summary.name}</a>
       <span class={`tag ${summary.status}`}>
         {summary.status === 'up' ? config.i18n.up : config.i18n.down}
       </span>


### PR DESCRIPTION
On the summary page I made the name of the site being monitored a hyperlink to the actual site.  What I found is that I frequently want to go from my monitored sites to the actual site and there is no linkage between the two.  This allows you to jump to the monitored site directly from the summary page. 