### PR TITLE
Adaptive graph

### DIFF
--- a/static/global.css
+++ b/static/global.css
@@ -200,6 +200,11 @@ a.error-button {
 article .graph {
   opacity: var(--graph-opacity);
   filter: var(--graph-filter);
-  -webkit-mask-image: linear-gradient(to left, black, transparent);
-  mask-image: linear-gradient(to left, black, transparent);
+}
+
+@media (max-width: 500px) {
+  .graph {
+    -webkit-mask-image: linear-gradient(to left, black, transparent);
+    mask-image: linear-gradient(to left, black, transparent);
+  }
 }

--- a/static/global.css
+++ b/static/global.css
@@ -200,4 +200,6 @@ a.error-button {
 article .graph {
   opacity: var(--graph-opacity);
   filter: var(--graph-filter);
+  -webkit-mask-image: linear-gradient(to left, black, transparent);
+  mask-image: linear-gradient(to left, black, transparent);
 }


### PR DESCRIPTION
Background transparency very important especially for dark theme because on mobile phones light text merges with dark graphics.

This PR makes graphs looks like:

![dark](https://user-images.githubusercontent.com/23360152/108976775-edb37600-7698-11eb-9cff-73535f2a566c.PNG)![light](https://user-images.githubusercontent.com/23360152/108976780-ef7d3980-7698-11eb-8dd5-195facbe2264.PNG)![ocean](https://user-images.githubusercontent.com/23360152/108976785-f015d000-7698-11eb-923f-8118103f0dfd.PNG)
