### PR TITLE
Add an option to hide the average response times

### DIFF
--- a/src/components/LiveStatus.svelte
+++ b/src/components/LiveStatus.svelte
@@ -133,21 +133,23 @@
             {@html config.i18n.overallUptime.split("$UPTIME")[1]}</span
           >
         </div>
-        <div>
-          {@html config.i18n.averageResponseTime.split("$TIME")[0]}
-          <span class="data"
-            >{selected === "day"
-              ? site.timeDay
-              : selected === "week"
-              ? site.timeWeek
-              : selected === "month"
-              ? site.timeMonth
-              : selected === "year"
-              ? site.timeYear
-              : site.time}
-            {@html config.i18n.averageResponseTime.split("$TIME")[1]}</span
-          >
-        </div>
+        {#if site.showAverageResponseType === undefined || site.showAverageResponseType}
+          <div>
+            {@html config.i18n.averageResponseTime.split("$TIME")[0]}
+            <span class="data"
+              >{selected === "day"
+                ? site.timeDay
+                : selected === "week"
+                ? site.timeWeek
+                : selected === "month"
+                ? site.timeMonth
+                : selected === "year"
+                ? site.timeYear
+                : site.time}
+              {@html config.i18n.averageResponseTime.split("$TIME")[1]}</span
+            >
+          </div>
+        {/if}
       </article>
     {/each}
   {/if}

--- a/src/components/LiveStatus.svelte
+++ b/src/components/LiveStatus.svelte
@@ -133,7 +133,7 @@
             {@html config.i18n.overallUptime.split("$UPTIME")[1]}</span
           >
         </div>
-        {#if site.showAverageResponseType === undefined || site.showAverageResponseType}
+        {#if site.showAverageResponseTime === undefined || site.showAverageResponseTime}
           <div>
             {@html config.i18n.averageResponseTime.split("$TIME")[0]}
             <span class="data"

--- a/src/components/Summary.svelte
+++ b/src/components/Summary.svelte
@@ -45,8 +45,10 @@
     <dl>
       <dt>{config.i18n.overallUptimeTitle}</dt>
       <dd>{summary.uptime}</dd>
-      <dt>{config.i18n.averageResponseTimeTitle}</dt>
-      <dd>{summary.time}{config.i18n.ms}</dd>
+      {#if summary.showAverageResponseType === undefined || summary.showAverageResponseType}
+        <dt>{config.i18n.averageResponseTimeTitle}</dt>
+        <dd>{summary.time}{config.i18n.ms}</dd>
+      {/if}
     </dl>
   {/if}
 </section>

--- a/src/components/Summary.svelte
+++ b/src/components/Summary.svelte
@@ -45,7 +45,7 @@
     <dl>
       <dt>{config.i18n.overallUptimeTitle}</dt>
       <dd>{summary.uptime}</dd>
-      {#if summary.showAverageResponseType === undefined || summary.showAverageResponseType}
+      {#if summary.showAverageResponseTime === undefined || summary.showAverageResponseTime}
         <dt>{config.i18n.averageResponseTimeTitle}</dt>
         <dd>{summary.time}{config.i18n.ms}</dd>
       {/if}


### PR DESCRIPTION
Now, you can add an option to hide the average response time for a site. For example:

```
sites:
  - name: Google
    url: https://www.google.com
    showAverageResponseTime: false
```

Mentions:
- https://github.com/upptime/upptime/discussions/376
- https://github.com/upptime/upptime/discussions/397
- https://github.com/upptime/upptime/issues/398