### PR TITLE
Remove useless "Subscribe to Updates" message for incidents page

### DIFF
--- a/i18n.yml
+++ b/i18n.yml
@@ -8,8 +8,7 @@ incidentFixed: Fixed
 incidentOngoing: Ongoing
 incidentOpenedAt: Opened at
 incidentClosedAt: Closed at
-incidentSubscribe: Subscribe to Updates
-incidentViewOnGitHub: View on GitHub
+incidentViewOnGitHub: View and Subscribe on GitHub
 incidentCommentSummary: Posted at $DATE by $AUTHOR
 incidentBack: ← Back to all incidents
 pastIncidents: Past Incidents

--- a/src/components/Incident.svelte
+++ b/src/components/Incident.svelte
@@ -120,11 +120,6 @@
       <div class="r">
         <p>
           <a href={`https://github.com/${config.owner}/${config.repo}/issues/${number}`}>
-            {config.i18n.incidentSubscribe}
-          </a>
-        </p>
-        <p>
-          <a href={`https://github.com/${config.owner}/${config.repo}/issues/${number}`}>
             {config.i18n.incidentViewOnGitHub}
           </a>
         </p>


### PR DESCRIPTION
The "Subscribe to Updates" text is completely useless since all it does is link to the GitHub issue in question, which the "View on GitHub" text is already doing.

In this PR did I do the following changes to improve this:

- Remove the "Subscribe to Updates" text
- Update "View on GitHub" to "View and Subscribe on GitHub"

I hope this is a good change. Again: The "Subscribe to Updates" text serves no purpose that the "View on GitHub" text doesn't cover already.

This would also - at least for me - solve the issue I mentioned in https://github.com/upptime/upptime/discussions/569