### PR TITLE
fix: global replace date and author incident comments

### DIFF
--- a/src/components/Incident.svelte
+++ b/src/components/Incident.svelte
@@ -133,10 +133,10 @@
         <div>
           {@html config.i18n.incidentCommentSummary
             .replace(
-              /\$DATE/,
+              /\$DATE/g,
               `<a href=${comment.html_url}>${new Date(comment.created_at).toLocaleString()}</a>`
             )
-            .replace(/\$AUTHOR/, `<a href=${comment.user.html_url}>@${comment.user.login}</a>`)}
+            .replace(/\$AUTHOR/g, `<a href=${comment.user.html_url}>@${comment.user.login}</a>`)}
         </div>
       </article>
     {/each}


### PR DESCRIPTION
This PR will fix scenarios where this is a i18n that contains $DATE and $AUTHOR multiple times. We do this in our project so that all content is both in english and french.

You'll notice in the below image the 2nd set of $DATE and $AUTHOR were not replaced since the `/g` was missing.

![image](https://user-images.githubusercontent.com/85885638/181548952-ba181f1e-2218-4592-9b6f-151b7826ee9c.png)
