### PR TITLE
Allow the use of other mirrors instead of raw.githubusercontent.com

### DIFF
--- a/i18n.yml
+++ b/i18n.yml
@@ -53,3 +53,4 @@ duration: Duration
 durationMin: $DURATION minutes
 incidentCompleted: Completed
 incidentScheduled: Scheduled
+GithubusercontentWebsiteUrl: https://raw.githubusercontent.com

--- a/i18n.yml
+++ b/i18n.yml
@@ -53,4 +53,3 @@ duration: Duration
 durationMin: $DURATION minutes
 incidentCompleted: Completed
 incidentScheduled: Scheduled
-GithubusercontentWebsiteUrl: https://raw.githubusercontent.com

--- a/src/components/LiveStatus.svelte
+++ b/src/components/LiveStatus.svelte
@@ -12,7 +12,7 @@
   let sites = [];
   if (!apiBaseUrl) apiBaseUrl = "https://api.github.com";
   const userContentBaseUrl = apiBaseUrl.includes("api.github.com")
-    ? `https://raw.githubusercontent.com`
+    ? `${config.i18n.GithubusercontentWebsiteUrl}`
     : apiBaseUrl;
   const graphsBaseUrl = `${userContentBaseUrl}/${owner}/${repo}/master/graphs`;
   let form = null;

--- a/src/components/LiveStatus.svelte
+++ b/src/components/LiveStatus.svelte
@@ -12,7 +12,7 @@
   let sites = [];
   if (!apiBaseUrl) apiBaseUrl = "https://api.github.com";
   const userContentBaseUrl = apiBaseUrl.includes("api.github.com")
-    ? `${config.i18n.GithubusercontentWebsiteUrl}`
+    ? `${config.githubUserContentBaseUrl || "https://raw.githubusercontent.com"}`
     : apiBaseUrl;
   const graphsBaseUrl = `${userContentBaseUrl}/${owner}/${repo}/master/graphs`;
   let form = null;

--- a/src/components/Summary.svelte
+++ b/src/components/Summary.svelte
@@ -9,7 +9,7 @@
   let { apiBaseUrl } = config["status-website"] || {};
   if (!apiBaseUrl) apiBaseUrl = "https://api.github.com";
   const userContentBaseUrl = apiBaseUrl.includes("api.github.com")
-    ? `https://raw.githubusercontent.com`
+    ? `${config.i18n.GithubusercontentWebsiteUrl}`
     : apiBaseUrl;
   const owner = config.owner;
   const repo = config.repo;

--- a/src/components/Summary.svelte
+++ b/src/components/Summary.svelte
@@ -9,7 +9,7 @@
   let { apiBaseUrl } = config["status-website"] || {};
   if (!apiBaseUrl) apiBaseUrl = "https://api.github.com";
   const userContentBaseUrl = apiBaseUrl.includes("api.github.com")
-    ? `${config.i18n.GithubusercontentWebsiteUrl}`
+    ? `${config.githubUserContentBaseUrl || "https://raw.githubusercontent.com"}`
     : apiBaseUrl;
   const owner = config.owner;
   const repo = config.repo;


### PR DESCRIPTION
I had a question the other day (at https://github.com/upptime/upptime/discussions/626)
In China for some reason some people may not be able to access raw.githubusercontent.com, so the status page will probably be inaccessible.
Therefore, I added a path to i18n.yml (GithubusercontentWebsiteUrl). This path defaults to raw.githubusercontent.com, however, the repository owner can modify it and use the raw.githubusercontent.com provided by others as needed raw.githubusercontent.com mirror service.