### PR TITLE
Seperate apiBaseUrl and userContentBaseUrl into two options

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -33,6 +33,8 @@ status-website:
   name: Upptime
   introTitle: "**Upptime** is the open-source uptime monitor and status page, powered entirely by GitHub."
   introMessage: This is a sample status page which uses **real-time** data from our [Github repository](https://github.com/upptime/upptime). No server required — just GitHub Actions, Issues, and Pages. [**Get your own for free**](https://github.com/upptime/upptime)
+  apiBaseUrl: https://api.github.com
+  userContentBaseUrl: https://raw.githubusercontent.com
   navbar:
     - title: Status
       href: /

--- a/src/components/LiveStatus.svelte
+++ b/src/components/LiveStatus.svelte
@@ -8,12 +8,12 @@
   const octokit = createOctokit();
   const owner = config.owner;
   const repo = config.repo;
-  let { apiBaseUrl } = config["status-website"] || {};
   let sites = [];
+
+  let { apiBaseUrl, userContentBaseUrl } = config["status-website"] || {};
   if (!apiBaseUrl) apiBaseUrl = "https://api.github.com";
-  const userContentBaseUrl = apiBaseUrl.includes("api.github.com")
-    ? `${config.githubUserContentBaseUrl || "https://raw.githubusercontent.com"}`
-    : apiBaseUrl;
+  if (!userContentBaseUrl) userContentBaseUrl = "https://raw.githubusercontent.com";
+
   const graphsBaseUrl = `${userContentBaseUrl}/${owner}/${repo}/master/graphs`;
   let form = null;
 

--- a/src/components/Summary.svelte
+++ b/src/components/Summary.svelte
@@ -6,11 +6,11 @@
 
   export let slug;
   let loading = true;
-  let { apiBaseUrl } = config["status-website"] || {};
+
+  let { apiBaseUrl,userContentBaseUrl } = config["status-website"] || {};
   if (!apiBaseUrl) apiBaseUrl = "https://api.github.com";
-  const userContentBaseUrl = apiBaseUrl.includes("api.github.com")
-    ? `${config.githubUserContentBaseUrl || "https://raw.githubusercontent.com"}`
-    : apiBaseUrl;
+  if (!userContentBaseUrl)  userContentBaseUrl = "https://raw.githubusercontent.com";
+
   const owner = config.owner;
   const repo = config.repo;
   let summary = null;

--- a/src/utils/createOctokit.js
+++ b/src/utils/createOctokit.js
@@ -1,7 +1,10 @@
 import { Octokit } from "@octokit/rest";
 import config from "../data/config.json";
 
-const { apiBaseUrl: baseUrl } = config["status-website"] || {};
+let { apiBaseUrl, userContentBaseUrl } = config["status-website"] || {};
+if (!apiBaseUrl) apiBaseUrl = "https://api.github.com";
+if (!userContentBaseUrl) userContentBaseUrl = "https://raw.githubusercontent.com";
+
 const userAgent = config.userAgent;
 
 export const createOctokit = () => {
@@ -12,6 +15,8 @@ export const createOctokit = () => {
     localStorage.getItem("personal-access-token")
   )
     token = localStorage.getItem("personal-access-token");
+
+  const baseUrl=apiBaseUrl;
   return new Octokit({
     baseUrl,
     userAgent,


### PR DESCRIPTION
Previously if 'apiBaseUrl' is defined, 'userContentBaseUrl' will have no effect.

This PR separates 'apiBaseUrl' and 'userContentBaseUrl' into two options in status-page.

Note that previously userContentBaseUrl was added directly to config which is non-intuitive.

This PR also adds 'apiBaseUrl' and 'userContentBaseUrl' to '.upptimerc.yml' so that it's very obvious to change.