### PR TITLE
feat: conditionally load either light or dark theme

### DIFF
--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -11,10 +11,34 @@
   {/if}
   {#if (config["status-website"] || {}).themeUrl}
     <link rel="stylesheet" href={(config["status-website"] || {}).themeUrl} />
-  {:else}
+  {:else if (config["status-website"] || {}).theme)}
     <link
       rel="stylesheet"
-      href={`${config.path}/themes/${(config["status-website"] || {}).theme || "light"}.css`}
+      href={`${config.path}/themes/${config["status-website"].theme}.css`}
+    />
+  {:else}
+    <!-- https://caniuse.com/prefers-color-scheme -->
+    <!-- https://web.dev/prefers-color-scheme/ -->
+    <script>
+      // If `prefers-color-scheme` is not supported, fall back to light mode.
+      // In this case, light.css will be downloaded with `highest` priority.
+      if (window.matchMedia('(prefers-color-scheme: dark)').media === 'not all') {
+        document.documentElement.style.display = 'none';
+        document.head.insertAdjacentHTML(
+          'beforeend',
+          '<link rel="stylesheet" href={`${config.path}/themes/light.css`} onload="document.documentElement.style.display = \'\'">',
+        );
+      }
+    </script>
+    <link
+      rel="stylesheet"
+      href={`${config.path}/themes/light.css`}
+      media="(prefers-color-scheme: light)"
+    />
+    <link
+      rel="stylesheet"
+      href={`${config.path}/themes/dark.css`}
+      media="(prefers-color-scheme: dark)"
     />
   {/if}
   <link rel="stylesheet" href={`${config.path}/global.css`} />


### PR DESCRIPTION
This resolves or helps to improve issues related to the following links:

- https://github.com/upptime/upptime/discussions/298
- https://github.com/upptime/upptime/discussions/732
- https://github.com/upptime/upptime/discussions/209
- https://github.com/upptime/upptime/discussions/219
- https://github.com/upptime/upptime/discussions/429
- https://github.com/upptime/upptime/issues/109

~95% of global browser usage supports this feature, therefore it should be implemented as the default for upptime.

References:
- <https://caniuse.com/prefers-color-scheme>
- <https://web.dev/prefers-color-scheme/>