### PR TITLE
Add "Last Updated" Field to UI based on build time

### DIFF
--- a/i18n.yml
+++ b/i18n.yml
@@ -14,6 +14,7 @@ incidentBack: ← Back to all incidents
 pastIncidents: Past Incidents
 pastIncidentsResolved: Resolved in $MINUTES minutes with $POSTS posts
 liveStatus: Live Status
+lastUpdated: "(Last Updated $BUILD_TIME)"
 overallUptime: "Overall uptime: $UPTIME"
 overallUptimeTitle: Overall uptime
 averageResponseTime: "Average response time: $TIMEms"

--- a/pre-process.ts
+++ b/pre-process.ts
@@ -19,11 +19,13 @@ export const preProcess = async () => {
     "status-website"?: {
       cname?: string;
     };
+    buildTime: string;
   } = load(await readFile(join("..", ".upptimerc.yml"), "utf8")) as any;
   if (!config.owner || !config.repo) throw new Error("Owner/repo not set");
   config.path = `https://${config.owner}.github.io/${config.repo}`;
   if (config["status-website"]?.cname) config.path = `https://${config["status-website"].cname}`;
   config.i18n = { ...i18n, ...config.i18n };
+  config.buildTime = new Date().toISOString();
   await ensureDir(join(".", "src", "data"));
   await writeJson(join(".", "src", "data", "config.json"), config);
 };

--- a/src/components/LiveStatus.svelte
+++ b/src/components/LiveStatus.svelte
@@ -104,15 +104,15 @@
       <article
         class={`${site.status} link graph`}
         style="--background: url('{`${graphsBaseUrl}/${site.slug}/response-time${
-          selected === 'day'
-            ? '-day'
-            : selected === 'week'
-            ? '-week'
-            : selected === 'month'
-            ? '-month'
-            : selected === 'year'
-            ? '-year'
-            : ''
+          selected === "day"
+            ? "-day"
+            : selected === "week"
+            ? "-week"
+            : selected === "month"
+            ? "-month"
+            : selected === "year"
+            ? "-year"
+            : ""
         }.png`}')"
       >
         <h4>

--- a/src/components/LiveStatus.svelte
+++ b/src/components/LiveStatus.svelte
@@ -39,7 +39,10 @@
 </script>
 
 <div class="f changed" bind:this={form}>
-  <h2>{config.i18n.liveStatus}</h2>
+  <h2>
+    {config.i18n.liveStatus}
+    {config.i18n.lastUpdated.replace("$BUILD_TIME", new Date(config.buildTime).toLocaleString())}
+  </h2>
   <form class="f r">
     <div>
       <input
@@ -101,17 +104,18 @@
       <article
         class={`${site.status} link graph`}
         style="--background: url('{`${graphsBaseUrl}/${site.slug}/response-time${
-          selected === "day"
-            ? "-day"
-            : selected === "week"
-            ? "-week"
-            : selected === "month"
-            ? "-month"
-            : selected === "year"
-            ? "-year"
-            : ""
+          selected === 'day'
+            ? '-day'
+            : selected === 'week'
+            ? '-week'
+            : selected === 'month'
+            ? '-month'
+            : selected === 'year'
+            ? '-year'
+            : ''
         }.png`}')"
-        ><h4>
+      >
+        <h4>
           <img class="icon" alt="" src={site.icon} />
           <a href={`${config.path}/history/${site.slug}`}>{site.name}</a>
         </h4>


### PR DESCRIPTION
Hi there. This PR adds a "Last Updated" field to the '"Live" Status' title in the web UI based on the last time the repository was builr. I'm not sure if there is a better way to go about this. I have Svelte fetching the current time as a ISO string during the preprocessing step, and writing it to the `config.json`. Then, on the client side I convert it to their locale time.

Closes upptime/upptime#798

Where I run `npm run dev` on my local machine, this is the status page I get.
<img width="914" alt="Screenshot 2023-06-13 at 12 52 20 PM" src="https://github.com/upptime/status-page/assets/774597/ed34029a-2ea1-40a4-9e20-caf693f0700e">

Feel free to squash and merge this PR. I accidentally has an auto-formatter on and so I had to make an additional commit to restore the small formatting changes.