### PR TITLE
Replace raw file fetch with api fetch.

### DIFF
--- a/src/components/LiveStatus.svelte
+++ b/src/components/LiveStatus.svelte
@@ -21,8 +21,9 @@
 
   onMount(async () => {
     try {
-      const res = await fetch(`${userContentBaseUrl}/${owner}/${repo}/master/history/summary.json`);
-      sites = await res.json();
+      const res = await fetch(`${apiBaseUrl}/repos/${owner}/${repo}/contents/history/summary.json`);
+      const json = await res.json();
+      sites = JSON.parse(atob(json.content));
     } catch (error) {
       handleError(error);
     }

--- a/src/components/Summary.svelte
+++ b/src/components/Summary.svelte
@@ -9,7 +9,6 @@
 
   let { apiBaseUrl,userContentBaseUrl } = config["status-website"] || {};
   if (!apiBaseUrl) apiBaseUrl = "https://api.github.com";
-  if (!userContentBaseUrl)  userContentBaseUrl = "https://raw.githubusercontent.com";
 
   const owner = config.owner;
   const repo = config.repo;
@@ -17,8 +16,9 @@
 
   onMount(async () => {
     try {
-      const res = await fetch(`${userContentBaseUrl}/${owner}/${repo}/master/history/summary.json`);
-      summary = (await res.json()).find((item) => item.slug === slug);
+      const res = await fetch(`${apiBaseUrl}/repos/${owner}/${repo}/contents/history/summary.json`);
+      const json = await res.json();
+      summary = JSON.parse(atob(json.content)).find((item) => item.slug === slug);
     } catch (error) {
       handleError(error);
     }


### PR DESCRIPTION
Hello!

I'm setting up upptime in a private repository, with a proxy for `api.github.com` which adds the `Authorization` header (will release as open-source).

The summary.json being retrieved using `raw.githubusercontent.com` is a challenge as the pat tokens won't work to retrieve the file.

This PR changes the requests to use `${apiBaseUrl}/repos/${owner}/${repo}/contents/history/summary.json` which returns the file for any public repo and if we add the `Authorization: Bearer token` header for private repos.