### PR TITLE
Release pipeline update

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,6 +1,6 @@
 name: Node CI
 on:
-  workflow:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,13 +10,13 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4.2.2
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4.3.0
         with:
           node-version: 14
       - name: Cache node modules
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v4.2.3
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,5 +1,6 @@
 name: Node CI
 on:
+  workflow:
   push:
     branches:
       - master

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,6 +1,5 @@
 name: Node CI
 on:
-  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,12 +1,13 @@
 name: "Stale Issues CI"
 on:
+  workflow_dispatch:
   schedule:
   - cron: "0 0 * * *"
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v9.1.0
       with:
         repo-token: ${{ secrets.GH_PAT }}
         stale-issue-message: "⚠️ This issue has not seen any activity in the past 2 months so I'm marking it as stale. I'll close it if it doesn't see any activity in the coming week."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: Test CI
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4.2.2
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4.3.0
         with:
           node-version: 14
       - name: Install dependencies


### PR DESCRIPTION
Release pipeline is using very old version of the actions. 
This updates those to the latest ones. 

I believe it should work 
![image](https://github.com/user-attachments/assets/6f44b2fb-5b1d-4b0a-9be3-75ac54728974)

I will make follow up PR's for the other actions