### PR TITLE
:bug: Respect baseUrl for default PNG favicon

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Build and test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -3,6 +3,10 @@
   import config from "../data/config.json";
   import snarkdown from "snarkdown";
   export let segment;
+
+  const statusWebsite = config["status-website"] || {};
+  const faviconBaseUrl = (statusWebsite.baseUrl || "").replace(/\/$/, "");
+  const defaultPngFavicon = `${faviconBaseUrl}/logo-192.png`;
 </script>
 
 <svelte:head>
@@ -52,7 +56,7 @@
   <link
     rel="icon"
     type="image/png"
-    href={(config["status-website"] || {}).favicon || `/logo-192.png`}
+    href={(config["status-website"] || {}).favicon || defaultPngFavicon}
   />
   {#if (config["status-website"] || {}).scripts}
     {#each (config["status-website"] || {}).scripts as script}<script


### PR DESCRIPTION
## Summary
- Uses the configured `status-website.baseUrl` for the default PNG favicon fallback
- Keeps custom `favicon` values unchanged
- Prevents base-path deployments from emitting `/logo-192.png`
- Moves PR Test CI from retired `ubuntu-18.04` to `ubuntu-latest` so the PR check can run

Fixes upptime/upptime#1145

## Test Plan
- `npx -y -p node@14 -p npm@9.9.4 -c "npm run build && npm run export"` with `status-website.baseUrl: /status-page-test`; verified exported HTML emits `/status-page-test/logo-192.png`, not `/logo-192.png`
- `npx -y -p node@14 -p npm@9.9.4 -c "npm run build"`
- `npx -y -p node@14 -p npm@9.9.4 -c "npm run test"`
- Parsed `.github/workflows/test.yml` as YAML; `actionlint` was not installed locally
