### PR TITLE
:bug: Respect configured page locale

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  testMatch: ["**/*.spec.ts"],
 };

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "post-process": "ts-node post-process.ts",
     "init-tests": "ts-node init-tests.ts",
     "dev": "npm run pre-process && sapper dev",
-    "build": "npm run init-tests && npm run pre-process && sapper build --legacy",
+    "build": "npm run init-tests && npm run unit-test && npm run pre-process && sapper build --legacy",
     "export": "npm run pre-process && npm run post-process",
     "start": "node __sapper__/build",
     "cy:run": "cypress run",
     "cy:open": "cypress open",
     "test": "npm run init-tests && run-p --race dev cy:run",
+    "unit-test": "jest --runInBand",
     "semantic-release": "semantic-release"
   },
   "repository": {

--- a/pre-process.spec.ts
+++ b/pre-process.spec.ts
@@ -1,0 +1,32 @@
+/// <reference types="jest" />
+
+import { getHtmlLanguage, updateTemplateLanguage } from "./pre-process";
+
+describe("preProcess template language", () => {
+  it("uses the configured locale for the HTML lang attribute", () => {
+    const template = '<!DOCTYPE html>\n<html lang="en">\n  <head></head>\n</html>\n';
+
+    expect(updateTemplateLanguage(template, "pt-BR")).toBe(
+      '<!DOCTYPE html>\n<html lang="pt-BR">\n  <head></head>\n</html>\n'
+    );
+  });
+
+  it("escapes the locale before writing it into the HTML attribute", () => {
+    const template = '<html lang="en"></html>';
+
+    expect(updateTemplateLanguage(template, 'en" data-test="bad')).toBe(
+      '<html lang="en&quot; data-test=&quot;bad"></html>'
+    );
+  });
+
+  it("falls back to English when no locale is configured", () => {
+    expect(getHtmlLanguage("   ")).toBe("en");
+    expect(updateTemplateLanguage("<html></html>")).toBe('<html lang="en"></html>');
+  });
+
+  it("replaces existing lang attributes instead of appending duplicates", () => {
+    expect(updateTemplateLanguage('<html lang="en" lang="en-US" dir="ltr"></html>', "fr-FR")).toBe(
+      '<html lang="fr-FR" dir="ltr"></html>'
+    );
+  });
+});

--- a/pre-process.ts
+++ b/pre-process.ts
@@ -1,6 +1,32 @@
-import { readFile, writeJson, ensureDir } from "fs-extra";
+import { readFile, writeFile, writeJson, ensureDir } from "fs-extra";
 import { load } from "js-yaml";
 import { join } from "path";
+
+export const escapeHtmlAttribute = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+export const getHtmlLanguage = (locale?: string) => {
+  const language = locale?.trim();
+  return language || "en";
+};
+
+export const updateTemplateLanguage = (template: string, locale?: string) => {
+  const language = escapeHtmlAttribute(getHtmlLanguage(locale));
+  return template.replace(/<html\b([^>]*)>/i, (_match, attributes: string) => {
+    const attributesWithoutLanguage = attributes.replace(/\s+lang=(["'])[^"']*\1/gi, "");
+    return `<html lang="${language}"${attributesWithoutLanguage}>`;
+  });
+};
+
+const writeTemplateLanguage = async (locale?: string) => {
+  const templatePath = join(".", "src", "template.html");
+  const template = await readFile(templatePath, "utf8");
+  await writeFile(templatePath, updateTemplateLanguage(template, locale));
+};
 
 export const preProcess = async () => {
   const i18n = load(await readFile(join(".", "i18n.yml"), "utf8")) as {
@@ -25,8 +51,9 @@ export const preProcess = async () => {
   config.path = `https://${config.owner}.github.io/${config.repo}`;
   if (config["status-website"]?.cname) config.path = `https://${config["status-website"].cname}${config["status-website"]?.baseUrl ?? ""}`;
   config.i18n = { ...i18n, ...config.i18n };
+  await writeTemplateLanguage(config.i18n.locale);
   await ensureDir(join(".", "src", "data"));
   await writeJson(join(".", "src", "data", "config.json"), config);
 };
 
-preProcess();
+if (require.main === module) preProcess();

--- a/src/template.html
+++ b/src/template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />


### PR DESCRIPTION
## Summary
- Uses the merged `i18n.locale` value to update the Sapper HTML template before build/export
- Escapes the locale before writing it into the `<html lang="...">` attribute
- Adds focused Jest coverage and runs it as part of `npm run build`

## Test Plan
- `npm ci`
- `npm run unit-test`
- `npm run build`
- `npm run export` (generated HTML uses `lang=en-US`)
- `npm test`

Fixes upptime/upptime#1005
