### PR TITLE
:bug: Route GitHub rate-limit errors to rate-limit page

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,14 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  testMatch: ["**/*.spec.ts"],
+  testMatch: ["**/*.spec.ts", "**/src/**/*.spec.js"],
+  transform: {
+    "^.+\\.ts$": "ts-jest",
+    "^.+\\.js$": [
+      "babel-jest",
+      {
+        presets: [["@babel/preset-env", { targets: { node: "current" } }]],
+      },
+    ],
+  },
 };

--- a/src/utils/createOctokit.js
+++ b/src/utils/createOctokit.js
@@ -24,15 +24,36 @@ export const createOctokit = () => {
   });
 };
 
+const getHeader = (headers, name) => {
+  if (!headers) return undefined;
+  return headers[name] || headers[name.toLowerCase()] || headers[name.toUpperCase()];
+};
+
+export const isRateLimitError = (error) => {
+  if (!error || error.message === "Bad credentials") return false;
+
+  const message = String(error.message || "").toLowerCase();
+  const documentationUrl = String(
+    error.documentation_url ||
+      (error.response && error.response.data && error.response.data.documentation_url) ||
+      ""
+  ).toLowerCase();
+  const status = error.status || (error.response && error.response.status);
+  const remaining = getHeader(error.response && error.response.headers, "x-ratelimit-remaining");
+
+  return (
+    message.indexOf("rate limit") > -1 ||
+    documentationUrl.indexOf("rate-limit") > -1 ||
+    (status === 403 && remaining === "0")
+  );
+};
+
+export const getErrorPath = (error) => (isRateLimitError(error) ? "/rate-limit-exceeded" : "/error");
+
 export const handleError = (error) => {
-  if (error.message === "Bad credentials") {
-    window.location.href = config.path + "/error";
-  } else if ((error.message || "").indexOf("rate limit exceeded") > -1) {
-    window.location.href = config.path + "/rate-limit-exceeded";
-  } else {
-    window.location.href = config.path + "/error";
-    console.log(error.message);
-  }
+  const errorPath = getErrorPath(error);
+  window.location.href = config.path + errorPath;
+  if (errorPath === "/error" && error && error.message !== "Bad credentials") console.log(error.message);
 };
 
 /**

--- a/src/utils/createOctokit.spec.js
+++ b/src/utils/createOctokit.spec.js
@@ -1,0 +1,63 @@
+jest.mock("@octokit/rest", () => ({
+  Octokit: jest.fn(),
+}));
+
+jest.mock(
+  "../data/config.json",
+  () => ({
+    path: "/status",
+    "status-website": {},
+  }),
+  { virtual: true }
+);
+
+const { getErrorPath, handleError } = require("./createOctokit");
+
+describe("status-page GitHub API error routing", () => {
+  beforeEach(() => {
+    delete global.window;
+    jest.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("routes secondary rate-limit errors to the rate-limit page", () => {
+    expect(
+      getErrorPath({
+        status: 403,
+        message: "You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+      })
+    ).toBe("/rate-limit-exceeded");
+  });
+
+  it("routes header-only primary rate-limit errors to the rate-limit page", () => {
+    expect(
+      getErrorPath({
+        status: 403,
+        message: "API request failed",
+        response: {
+          headers: {
+            "x-ratelimit-remaining": "0",
+          },
+        },
+      })
+    ).toBe("/rate-limit-exceeded");
+  });
+
+  it("keeps bad credentials on the generic error page", () => {
+    expect(getErrorPath({ status: 401, message: "Bad credentials" })).toBe("/error");
+  });
+
+  it("uses the rate-limit route when redirecting", () => {
+    global.window = { location: { href: "" } };
+
+    handleError({
+      status: 403,
+      message: "You have exceeded a secondary rate limit.",
+    });
+
+    expect(global.window.location.href).toBe("/status/rate-limit-exceeded");
+  });
+});


### PR DESCRIPTION
## Summary
- Detect GitHub API rate-limit failures more robustly in the status-page client.
- Route secondary rate-limit messages and `x-ratelimit-remaining: 0` errors to `/rate-limit-exceeded` instead of `/error`.
- Add focused Jest coverage for the error-routing helper.

Fixes upptime/upptime#1002

## Test plan
- `npm ci` with Node 14.21.3 / npm 6.14.18
- RED: `npm run unit-test -- --runTestsByPath src/utils/createOctokit.spec.js --runInBand` failed before the fix
- GREEN: `npm run unit-test -- --runTestsByPath src/utils/createOctokit.spec.js --runInBand`
- `npm run unit-test`
- `npm run build`
- `npm run test`

## Notes
- This repo's current `master` release job is already blocked by an invalid `NPM_TOKEN` from the previous merge, so I do not expect to merge/release this until that release-infra blocker is handled.
